### PR TITLE
Add Algolia search

### DIFF
--- a/algolia.js
+++ b/algolia.js
@@ -1,0 +1,134 @@
+/*jshint node:true, unused:true */
+var ent = require('ent');
+var keys = require('./keys.json');
+var algoliasearch = require('algoliasearch');
+var client = algoliasearch(keys.algolia.appId, keys.algolia.writeAPIKey);
+
+
+function arrayChunk(list, chunkSize) {
+  var chunks = [];
+  var max = list.length;
+  var i = 0;
+
+  while (i < max) {
+    chunks.push(list.slice(i, i += chunkSize));
+  }
+  return chunks;
+}
+
+function stringDateToUnixTimestamp(date) {
+  return Math.floor(new Date(date).getTime());
+}
+
+function formatRecordsForSearch(records, type) {
+  return records.map(function(record) {
+    record.type = type;
+    record.keywords = record.keywords.split(',');
+    record.created = stringDateToUnixTimestamp(record.created);
+    record.modified = stringDateToUnixTimestamp(record.modified);
+    // There currently is an issue in the way the Algolia API handle HTML chars
+    // in the _highlightResult attribute. All htmlencoded data gets decoded, so
+    // we need to encode it twice to get the correct display.
+    record.description_encoded = ent.encode(ent.encode(record.description || ''));
+    return record;
+  });
+}
+
+function promiseLog(text) {
+  return function(req) {
+    console.info(text);
+    return req;
+  };
+}
+
+function pushDataToAlgolia(sources) {
+  var indexName = 'reactparts';
+  var indexNameTmp = indexName + '_tmp';
+  var indexTmp = client.initIndex(indexNameTmp);
+
+  var allRecords = [];
+  sources.forEach(function(source) {
+    var records = require(source.file);
+    var type = source.type;
+    allRecords = allRecords.concat(formatRecordsForSearch(records, type));
+  });
+
+  return configureIndex(indexTmp)
+    .then(promiseLog('[' + indexNameTmp +']: Configured index'))
+    .then(pushRecords(allRecords, indexTmp))
+    .then(promiseLog('[' + indexNameTmp +']: Pushed all chunks'))
+    .then(overwriteTmpIndex(client, indexNameTmp, indexName))
+    .then(promiseLog('[' + indexNameTmp +']: Delete tmp index'));
+}
+
+function configureIndex(index) {
+  return index.setSettings({
+    attributesToIndex: [
+      'unordered(name)',
+      'unordered(description)',
+      'unordered(keywords)',
+      'githubUser',
+      'repo,homepage',
+      'description_encoded' // To have highlight in it
+    ],
+    attributesToRetrieve: [
+      'description',
+      'description_encoded',
+      'downloads',
+      'githubUser',
+      'homepage',
+      'latestVersion',
+      'modified',
+      'name',
+      'platforms',
+      'stars'
+    ],
+    attributesForFacetting: [
+      'type',
+      'keywords',
+      'githubUser'
+    ],
+    customRanking: [
+      'desc(stars)',
+      'desc(downloads)',
+      'desc(modified)',
+      'desc(created)'
+    ],
+    minWordSizefor1Typo: 3,
+    minWordSizefor2Typos: 7,
+    hitsPerPage: 20,
+    highlightPreTag: '<mark>',
+    highlightPostTag: '</mark>'
+  });
+}
+
+function pushRecords(records, index) {
+  var pushOrders = [];
+
+  arrayChunk(records, 500).forEach(function(chunkedRecords) {
+    pushOrders.push(index.addObjects(chunkedRecords));
+  });
+
+  return function() {
+    return Promise.all(pushOrders);
+  };
+}
+
+// Replace the real index with the temporary one
+// Allow for atomic updates
+function overwriteTmpIndex(client, indexNameTmp, indexName) {
+  return function() {
+    return client.moveIndex(indexNameTmp, indexName)
+      .then(client.deleteIndex(indexNameTmp));
+  };
+}
+
+pushDataToAlgolia([
+  {
+    file: './data/react-web.json',
+    type: 'web'
+  }, {
+    file: './data/react-native.json',
+    type: 'native'
+  }
+]);

--- a/keys.json.example
+++ b/keys.json.example
@@ -2,5 +2,9 @@
   "github": {
     "username": "USERNAME",
     "password": "PASSWORD"
+  },
+  "algolia": {
+    "appId": "APPLICATION_ID",
+    "writeAPIKey": "WRITE_API_KEY"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "node": "4.1.x"
   },
   "dependencies": {
+    "algoliasearch": "^3.8.1",
     "async": "^1.4.2",
     "babel": "^5.8.23",
     "babelify": "^6.3.0",
@@ -12,6 +13,7 @@
     "co-request": "^1.0.0",
     "connect-cachify": "^0.0.17",
     "ejs": "^2.3.4",
+    "ent": "^2.2.0",
     "express": "^4.13.3",
     "isomorphic-fetch": "^2.1.1",
     "react": "^0.13.3",
@@ -31,7 +33,6 @@
     "js:build": "browserify src/app.jsx -t babelify --outfile assets/app.js",
     "js:minify": "uglifyjs assets/app.js -o assets/app.min.js",
     "js:watch": "watchify src/app.jsx -t babelify --outfile assets/app.js",
-
     "download:all": "curl -L http://registry.npmjs.eu/-/all -o data/npm.json",
     "download:yesterday": "curl -L https://registry.npmjs.org/-/all/static/yesterday.json -o data/npm.json",
     "parse": "node parse.js",
@@ -45,9 +46,9 @@
     "bender:set": "git config user.name 'Bender Rodriguez' && git config user.email 'bender@react.parts'",
     "bender:unset": "git config --unset-all user.name && git config --unset-all user.email",
     "push": "git add components && git commit -m 'Update lists of react components' && git push origin master",
-
     "update": "npm run download:yesterday && npm run parse",
     "prepare": "npm run fetch:all && npm run live",
-    "publish": "npm run upload && npm run bender:set && npm run push && npm run bender:unset"
+    "publish": "npm run upload && npm run bender:set && npm run push && npm run bender:unset",
+    "algolia": "node algolia.js"
   }
 }

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -13,6 +13,7 @@ import Pagination from './pagination-component.jsx';
 import Scroller from './scroller-component.jsx';
 import Footer from './footer-component.jsx';
 import Twitter from './twitter-component.jsx';
+import getSearchResults from './get-search-results'
 import sortBy from './sort';
 
 let Route = Router.Route;
@@ -24,28 +25,36 @@ export var App = React.createClass({
     router: React.PropTypes.func
   },
   propTypes: {
-    initialComponents: React.PropTypes.object.isRequired,
-    perPage: React.PropTypes.number,
-    debugMode: React.PropTypes.bool
+    components: React.PropTypes.array.isRequired,
+    currentPage: React.PropTypes.number,
+    debugMode: React.PropTypes.bool,
+    searchQuery: React.PropTypes.string,
+    searchCount: React.PropTypes.number,
+    type: React.PropTypes.string
   },
   getDefaultProps() {
     return {
-      perPage: 20,
-      debugMode: false
+      currentPage: 0,
+      debugMode: false,
+      perPage: 20
     };
   },
   getInitialState() {
     return {
-      components: this.props.initialComponents,
-      filtered: this.props.initialComponents[this.props.params.type],
-      searchQuery: "",
+      components: this.props.components,
+      currentPage: this.props.currentPage,
+      searchQuery: this.props.searchQuery,
+      searchCount: this.props.searchCount,
+      type: this.props.type
     };
   },
   render() {
     let title = "React.parts";
-    let type = this.props.params.type;
-    let components = this.sortComponents(this.state.filtered);
-    let componentsForPage = this.componentsForPage(components);
+    let type = this.state.type;
+    let components = this.state.components;
+    let searchCount = this.state.searchCount;
+    let debugMode = this.props.debugMode;
+    let loading = this.state.loading;
 
     let styles = {
       container:  {
@@ -62,7 +71,7 @@ export var App = React.createClass({
       }
     };
     return (
-      <Scroller className="u-scrollable" position={ this.props.debugMode ? "same" : "top" } style={styles.container}>
+      <Scroller className="u-scrollable" position={ debugMode ? "same" : "top" } style={styles.container}>
         <Navbar title={title} height={this.remCalc(55)} onSearch={this.handleSearch} />
 
         <div style={styles.content}>
@@ -72,91 +81,61 @@ export var App = React.createClass({
           </Tabs>
 
           <RouteHandler
-            components={componentsForPage}
-            debugMode={this.props.debugMode}
-            loading={this.state.loading}
+            components={components}
+            debugMode={debugMode}
+            loading={loading}
           />
 
           <Pagination
             to="components"
             params={{ type }}
-            currentPage={this.currentPage()}
+            currentPage={this.state.currentPage}
             perPage={this.props.perPage}
-            totalItems={components.length}
+            searchCount={searchCount}
           />
 
           <Footer />
         </div>
-
         <Twitter />
+
       </Scroller>
     );
   },
   componentWillReceiveProps(newProps) {
-    let type = newProps.params.type;
-    let components = this.state.components;
-    let searchQuery = this.state.searchQuery;
+    var searchQuery = this.state.searchQuery;
+    var currentType = this.state.type;
+    var newType = newProps.params.type;
+    var type = newType || currentType
+    var page = newProps.query.page || this.state.currentPage;
 
-    // If the user changed tab, and we don't have the data, fetch it
-    if (!components[type] || components[type].length === 0) {
-      // Clear the list and display loading message
-      this.setState({ components, filtered: [], loading: true });
+    // Revert to first page if switching type
+    if (newType !== currentType) {
+      page = 0;
+    }
 
-      window.fetch(`/api/components/${type}`).then((response) => {
-        response.json().then((data) => {
-          components[type] = data;
-          // Update both the complete and filtered components lists
-          let filtered = this.filterForSearch(components[type], searchQuery);
-          this.setState({ components, filtered, loading: false });
-        });
+    this.handleSearch({ searchQuery, type, page});
+  },
+  handleSearch({searchQuery = '', type = this.state.type, page = this.state.currentPage}) {
+    var searchOptions = {
+      query: searchQuery,
+      type: type,
+      page: page,
+      perPage: this.props.perPage
+    }
+    getSearchResults(searchOptions).then((data) => {
+      this.setState({ 
+        type: type,
+        searchQuery: searchQuery,
+        components: data.components,
+        searchCount: data.searchCount,
+        currentPage: data.page
       });
-    } else {
-      // We already have the data, simply reset the search filters
-      let filtered = this.filterForSearch(components[type], searchQuery);
-      this.setState({ filtered, loading: false });
-    }
-  },
-  handleSearch(searchQuery) {
-    // Get all components available for the current tab
-    let components = this.state.components[this.props.params.type];
-
-    let filtered = this.filterForSearch(components, searchQuery);
-    this.setState({ filtered, searchQuery });
-
-    // TODO Improve this code: return to the first page
-    this.context.router.transitionTo("/:type", this.props.params, {});
-  },
-  filterForSearch(components, query) {
-    var results = components;
-
-    query.split(/\s+/).forEach(function(term) {
-      results = results.filter((c) => (
-        c.name.toLowerCase().indexOf(term) != -1 ||
-        (c.description || "").toLowerCase().indexOf(term) != -1 ||
-        c.keywords.toLowerCase().indexOf(term) != -1 ||
-        c.githubUser.toLowerCase().toLowerCase() == term
-      ));
     });
-    return results;
-  },
-  sortComponents(components) {
-    if (this.state.searchQuery) {
-      // Sort results by stars
-      return components.sort(sortBy("stars", Number, false));
-    } else {
-      // Default sorting from server
-      return components;
-    }
   },
   currentPage() {
     var currentPage = parseInt(this.props.query.page); // May return NaN
     if (isNaN(currentPage)) currentPage = 1; // This works, even for 0
     return currentPage;
-  },
-  componentsForPage(items) {
-    let i = Math.max(0, (this.currentPage() - 1) * this.props.perPage);
-    let j = Math.max(0, this.currentPage() * this.props.perPage);
-    return items.slice(i, j);
   }
 });
 
@@ -169,10 +148,7 @@ export var routes = (
 if (typeof(document) !== "undefined") {
   Router.run(routes, Router.HistoryLocation, function(Handler, state) {
     React.render(
-      <Handler {...state}
-        initialComponents={window.initialComponents}
-        debugMode={window.debugMode}
-      />,
+      <Handler {...state} {...window.initialData} />,
       document.getElementById("container")
     );
   });

--- a/src/get-search-results.js
+++ b/src/get-search-results.js
@@ -1,0 +1,37 @@
+/*jshint esnext:true, node:true */
+'use strict';
+var AlgoliaSearch = require('algoliasearch');
+var algoliaAppId = 'POLDBPK8LK';
+var algoliaSearchAPIKey = 'e23f93113f47b926771abfcf68496ef5';
+var AlgoliaClient = AlgoliaSearch(algoliaAppId, algoliaSearchAPIKey);
+var AlgoliaIndex = AlgoliaClient.initIndex('reactparts');
+
+function getSearchResults({ query = '', type = 'native', page = 0, perPage = 20 }) {
+  var searchConfig = {
+    facets: ['type'],
+    facetFilters: ['type:' + type],
+    hitsPerPage: perPage,
+    page: page
+  };
+
+  return AlgoliaIndex.search(query, searchConfig).then(function(data) {
+    // Search results
+    var searchResults = data.hits.map(function(hit) {
+      hit.modified = new Date(hit.modified).toISOString();
+      hit.name_highlight = hit._highlightResult.name.value;
+      hit.description_highlight = hit._highlightResult.description_encoded.value;
+      hit.githubUser_highlight = hit._highlightResult.githubUser.value;
+      delete hit._highlightResult;
+      return hit;
+    });
+
+    return {
+      components: searchResults,
+      searchCount: data.nbHits,
+      page: data.page
+    }
+  });
+}
+
+export default getSearchResults;
+

--- a/src/item-component.jsx
+++ b/src/item-component.jsx
@@ -146,17 +146,13 @@ let ComponentItem = React.createClass({
         <div className="u-displayFlex" style={styles.content}>
           <div style={styles.main}>
             <h3 style={styles.title}>
-              <span style={styles.name}>
-                {this.props.name}
-              </span>
+              <span style={styles.name} dangerouslySetInnerHTML={{__html: this.props.name_highlight}}></span>
               <span style={styles.author}>
-                v{this.props.latestVersion} <TimeAgo dateTime={this.props.modified} /> by {this.props.githubUser}
+                v{this.props.latestVersion} <TimeAgo dateTime={this.props.modified} /> by <span dangerouslySetInnerHTML={{__html: this.props.githubUser_highlight}}></span>
               </span>
               <span style={styles.visited}>visited</span>
             </h3>
-            <div style={styles.body}>
-              {this.props.description}
-            </div>
+            <div style={styles.body} dangerouslySetInnerHTML={{__html: this.props.description_highlight}}></div>
 
             { this.props.platforms &&
             <div className="u-displayFlex" style={styles.footer}>

--- a/src/navbar-component.jsx
+++ b/src/navbar-component.jsx
@@ -114,8 +114,7 @@ let Navbar = React.createClass({
   handleKeyUp() {
     var field = React.findDOMNode(this.refs.search);
     var value = field.value.trim().toLowerCase();
-    this.props.onSearch(value);
-  }
+    this.props.onSearch({ searchQuery: value });}
 });
 
 export default Navbar;

--- a/src/pagination-component.jsx
+++ b/src/pagination-component.jsx
@@ -8,14 +8,14 @@ let Pagination = React.createClass({
   propTypes: {
     currentPage: React.PropTypes.number.isRequired,
     perPage: React.PropTypes.number.isRequired,
-    totalItems: React.PropTypes.number.isRequired
+    searchCount: React.PropTypes.number.isRequired
   },
   render() {
     return (
       <Tabs>
         <Tab {...this.props}
           query={{page: this.previousPage()}}
-          disabled={this.props.currentPage <= 1}>
+          disabled={this.props.currentPage <= 0}>
             Previous
         </Tab>
         <Tab {...this.props}
@@ -27,7 +27,7 @@ let Pagination = React.createClass({
     );
   },
   lastPage() {
-    return Math.ceil(this.props.totalItems / this.props.perPage);
+    return Math.ceil(this.props.searchCount / this.props.perPage) - 1;
   },
   previousPage() {
     // Math.min is only done to deal with tempered page numbers (such as -1)

--- a/src/tabs-component.jsx
+++ b/src/tabs-component.jsx
@@ -34,7 +34,8 @@ export let Tab = React.createClass({
       },
       selectedTab: {
         background: "#fff",
-        fontWeight: 600
+        fontWeight: 600,
+        borderTop: '2px solid'
       },
       disabledTab: {
         color: "#aaa",

--- a/views/template.ejs
+++ b/views/template.ejs
@@ -46,6 +46,11 @@
       color: #777;
     }
 
+    /* Highlight search color */
+    mark {
+      background-color: rgba(37, 59, 107, 0.1);
+    }
+
     ::-webkit-input-placeholder {
       color: #fff;
       font-weight: 300;
@@ -82,8 +87,7 @@
   <div id="container"><%- output %></div>
 
   <script>
-    window.debugMode = <%- debugMode %>;
-    window.initialComponents = <%- JSON.stringify(initialComponents) %>;
+    window.initialData = <%- initialData %>;
   </script>
   <%- cachify_js("/app.min.js") %>
 </body>


### PR DESCRIPTION
As discussed in #11, this is the PR to add Algolia search to ReactParts.

You just have to call `npm run algolia` to push all the data to your Algolia index (this will read local `./data/react-*.json` files). I've updated your account to a free one, with unlimited operations and 50.000 records. There currently is 2314 plugins saved, so you won't hit the limit anytime soon :)

Just update the `keys.json` with your Algolia credentials (you can find them in your Dashboard, under the Credentials link on the left). Fill in your `appID` and the write API key (you can find it at the bottom of the page, under "Restricted keys", named "ReactParts - Write"). Those two informations are ony needed for pushing data, you still do not have to deploy the `keys.json` file anywhere.

I've replaced the initial loop+regexp search and initial display with a call to the Algolia API (all relevant code is contained in `get-search-results.js`). I just had to change a bit the pagination logic (our pages starts at 0, not 1), add a bit of CSS and `dangerouslySetInnerHTML` for the highlight. There might be a few `var` instead of `let` here and there...

I kept the highlight in this PR because as we're doing fuzzy search, it is often not obvious why a result is displayed without the highlight hint. As requested, I did not include the number of results in the tab headers.

I've pushed it to heroku here : https://afternoon-savannah-7018.herokuapp.com/
